### PR TITLE
imagemagick limits

### DIFF
--- a/config.local.php.SAMPLE
+++ b/config.local.php.SAMPLE
@@ -14,8 +14,8 @@ $TMP_DIR = '/var/tmp';              // which dir to use for tmp files (w/o trail
 $LOG_DIR = null;                    // which dir to user for log files in debug mode
 $TMP_DIR_IMAGEMAGICK = null;        // use different tmp dir for ImageMagick (set to 'null' to avoid overriding)
 $CONVERT_TIMEOUT = null;            // if not null, let "convert" (imagemagick) work no more than this amount (use '20s' means 20 seconds)
+$ALLOWED_WIDTHS = null;             // Allowed target widths as array [230, 560]
 $CONVERT_LIMITS = [                 // imagemagick limits, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
   'memory' => '32MiB ',
   'time' => '64MiB',
 ];
-$ALLOWED_WIDTHS = null;             // Allowed target widths as array [230, 560]

--- a/config.local.php.SAMPLE
+++ b/config.local.php.SAMPLE
@@ -14,4 +14,7 @@ $TMP_DIR = '/var/tmp';              // which dir to use for tmp files (w/o trail
 $LOG_DIR = null;                    // which dir to user for log files in debug mode
 $TMP_DIR_IMAGEMAGICK = null;        // use different tmp dir for ImageMagick (set to 'null' to avoid overriding)
 $CONVERT_TIMEOUT = null;            // if not null, let "convert" (imagemagick) work no more than this amount (use '20s' means 20 seconds)
+$CONVERT_LIMIT_MEMORY = '32MiB';    // imagemagick memory limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
+$CONVERT_LIMIT_MAP = '64MiB';       // imagemagick memory limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
+$CONVERT_LIMIT_TIME = null;         // (alternative to $CONVERT_TIMEOUT) imagemagick time limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
 $ALLOWED_WIDTHS = null;             // Allowed target widths as array [230, 560]

--- a/config.local.php.SAMPLE
+++ b/config.local.php.SAMPLE
@@ -14,7 +14,8 @@ $TMP_DIR = '/var/tmp';              // which dir to use for tmp files (w/o trail
 $LOG_DIR = null;                    // which dir to user for log files in debug mode
 $TMP_DIR_IMAGEMAGICK = null;        // use different tmp dir for ImageMagick (set to 'null' to avoid overriding)
 $CONVERT_TIMEOUT = null;            // if not null, let "convert" (imagemagick) work no more than this amount (use '20s' means 20 seconds)
-$CONVERT_LIMIT_MEMORY = '32MiB';    // imagemagick memory limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
-$CONVERT_LIMIT_MAP = '64MiB';       // imagemagick memory limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
-$CONVERT_LIMIT_TIME = null;         // (alternative to $CONVERT_TIMEOUT) imagemagick time limit, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
+$CONVERT_LIMITS = [                 // imagemagick limits, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
+  'memory' => '32MiB ',
+  'time' => '64MiB',
+];
 $ALLOWED_WIDTHS = null;             // Allowed target widths as array [230, 560]

--- a/config.local.php.SAMPLE
+++ b/config.local.php.SAMPLE
@@ -17,5 +17,5 @@ $CONVERT_TIMEOUT = null;            // if not null, let "convert" (imagemagick) 
 $ALLOWED_WIDTHS = null;             // Allowed target widths as array [230, 560]
 $CONVERT_LIMITS = [                 // imagemagick limits, see https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885
   'memory' => '32MiB ',
-  'time' => '64MiB',
+  'map' => '64MiB',
 ];

--- a/index.php
+++ b/index.php
@@ -231,7 +231,7 @@ function resizeAnimatedGif($f, $width, $height, $master = NULL)
             putenv("MAGICK_TMPDIR=$TMP_DIR_IMAGEMAGICK");
         }
         $prefix = "";
-        global $CONVERT_TIMEOUT, $CONVERT_LIMIT_MEMORY, $CONVERT_LIMIT_MAP;
+        global $CONVERT_TIMEOUT, $CONVERT_LIMITS;
         if (!is_null($CONVERT_TIMEOUT)) {
             $prefix = "timeout $CONVERT_TIMEOUT ";
         }

--- a/index.php
+++ b/index.php
@@ -235,11 +235,10 @@ function resizeAnimatedGif($f, $width, $height, $master = NULL)
         if (!is_null($CONVERT_TIMEOUT)) {
             $prefix = "timeout $CONVERT_TIMEOUT ";
         }
-        if (isset($CONVERT_LIMIT_MEMORY)) {
-            $_image_magick .= " -limit memory $CONVERT_LIMIT_MEMORY";
-        }
-        if (isset($CONVERT_LIMIT_MAP)) {
-            $_image_magick .= " -limit map $CONVERT_LIMIT_MAP";
+        if (!is_null($CONVERT_LIMIT)) {
+            foreach ($CONVERT_LIMIT as $limit_k => $limit_v) {
+                $_image_magick .= " -limit $limit_k $limit_v";
+            }
         }
         logTime("Start ImageMagick call at line " . __LINE__ );
         exec($prefix . escapeshellcmd($_image_magick) . ' ' . $f . ' -coalesce -strip -resize ' . $dim . ' ' . $f, $output, $status);

--- a/index.php
+++ b/index.php
@@ -231,9 +231,15 @@ function resizeAnimatedGif($f, $width, $height, $master = NULL)
             putenv("MAGICK_TMPDIR=$TMP_DIR_IMAGEMAGICK");
         }
         $prefix = "";
-        global $CONVERT_TIMEOUT;
+        global $CONVERT_TIMEOUT, $CONVERT_LIMIT_MEMORY, $CONVERT_LIMIT_MAP;
         if (!is_null($CONVERT_TIMEOUT)) {
             $prefix = "timeout $CONVERT_TIMEOUT ";
+        }
+        if (isset($CONVERT_LIMIT_MEMORY)) {
+            $_image_magick .= " -limit memory $CONVERT_LIMIT_MEMORY";
+        }
+        if (isset($CONVERT_LIMIT_MAP)) {
+            $_image_magick .= " -limit map $CONVERT_LIMIT_MAP";
         }
         logTime("Start ImageMagick call at line " . __LINE__ );
         exec($prefix . escapeshellcmd($_image_magick) . ' ' . $f . ' -coalesce -strip -resize ' . $dim . ' ' . $f, $output, $status);

--- a/index.php
+++ b/index.php
@@ -235,9 +235,11 @@ function resizeAnimatedGif($f, $width, $height, $master = NULL)
         if (!is_null($CONVERT_TIMEOUT)) {
             $prefix = "timeout $CONVERT_TIMEOUT ";
         }
-        if (!is_null($CONVERT_LIMIT)) {
-            foreach ($CONVERT_LIMIT as $limit_k => $limit_v) {
-                $_image_magick .= " -limit $limit_k $limit_v";
+        if (!is_null($CONVERT_LIMITS)) {
+            foreach ($CONVERT_LIMITS as $limit_k => $limit_v) {
+                if (!is_null($limit_v)) {
+                    $_image_magick .= " -limit $limit_k $limit_v";
+                }
             }
         }
         logTime("Start ImageMagick call at line " . __LINE__ );


### PR DESCRIPTION
Allow to specify `$CONVERT_LIMITS` in config.
See https://www.imagemagick.org/discourse-server/viewtopic.php?t=10885

> By default the limits are 768 files, 3GB of image area, 1.5GiB memory, 3GiB memory map, and 18.45EB of disk. These limits are adjusted relative to the available resources on your computer if this information is available. When any limit is reached, ImageMagick fails in some fashion but attempts to take compensating actions, if possible. For example, the following limits memory:
> 
> -limit memory 32MiB -limit map 64MiB
> 
> -limit type value
> 
> Set the pixel cache resource limit.
> 
> Choose from: area, disk, file, map, memory, threads, or time
